### PR TITLE
WTK-362 Add support for export netex blocks events

### DIFF
--- a/app/Examples/EventsExample.js
+++ b/app/Examples/EventsExample.js
@@ -16,6 +16,7 @@ const EventsExample = props => {
         locale="nb"
         showDateFilter={true}
         showNewDeliveriesFilter={true}
+        hideIgnoredExportNetexBlocks={false}
       />
     </div>
   )

--- a/src/components/EventDetails.js
+++ b/src/components/EventDetails.js
@@ -77,8 +77,10 @@ class EventDetails extends React.Component {
       locale,
       includeLevel2,
       showDateFilter,
-      showNewDeliveriesFilter
+      showNewDeliveriesFilter,
+      hideIgnoredExportNetexBlocks = true
     } = this.props;
+
     const {
       activePageIndex,
       endStateFilter,
@@ -211,6 +213,7 @@ class EventDetails extends React.Component {
                     key={'event-group-' + listItem.chouetteJobId + '-' + index}
                     groups={eventGroup}
                     listItem={listItem}
+                    hideIgnoredExportNetexBlocks={hideIgnoredExportNetexBlocks}
                   />
                 </div>
               );

--- a/src/components/EventStepper.js
+++ b/src/components/EventStepper.js
@@ -30,6 +30,7 @@ class EventStepper extends React.Component {
       'DATASPACE_TRANSFER',
       'VALIDATION_LEVEL_2',
       'EXPORT',
+      'EXPORT_NETEX_BLOCKS',
       'BUILD_GRAPH',
       'OTP2_BUILD_GRAPH',
       'EXPORT_NETEX'
@@ -108,20 +109,28 @@ class EventStepper extends React.Component {
     return groups;
   }
 
-  bullet(formattedGroups, groups, locale, includeLevel2) {
-    const columnStyle = {
+  bullet(formattedGroups, groups, locale, includeLevel2, hideIgnoredExportNetexBlocks) {
+    const columnStyle = (column) => ({
       display: 'flex',
       flexDirection: 'column',
       justifyContent: 'space-between',
-      height: 45
-    };
+      height: Array.isArray(column) && column.length > 2 ? 90 : 45
+    });
 
     return Object.keys(formattedGroups).map((group, index) => {
       let column;
       let event = formattedGroups[group];
 
       if (Array.isArray(event)) {
-        column = Object.keys(event).map((key, i) => {
+        column = Object.keys(event)
+          .filter((key) => {
+            if (hideIgnoredExportNetexBlocks && key === 'EXPORT_NETEX_BLOCKS') {
+              return event[key].endState !== 'IGNORED';
+            }
+
+            return true;
+          })
+          .map((key, i) => {
           return this.renderEvent(
             event[key],
             event,
@@ -146,7 +155,7 @@ class EventStepper extends React.Component {
         );
       }
       return (
-        <div key={'bullet-' + index} style={columnStyle}>
+        <div key={'bullet-' + index} style={columnStyle(column)}>
           {column}
         </div>
       );
@@ -225,12 +234,12 @@ class EventStepper extends React.Component {
       display: 'flex',
       flexDirection: 'row',
       alignContent: 'center',
-      alignItems: 'center',
+      alignItems: 'start',
       justifyContent: 'center',
       marginTop: 10
     };
 
-    const { groups, listItem, locale, includeLevel2 } = this.props;
+    const { groups, listItem, locale, includeLevel2, hideIgnoredExportNetexBlocks } = this.props;
     const { expanded } = this.state;
 
     let formattedGroups = this.addUnlistedStates(groups);
@@ -243,11 +252,11 @@ class EventStepper extends React.Component {
 
     this.createCombinedSplit(
       formattedGroups,
-      ['BUILD_GRAPH', 'OTP2_BUILD_GRAPH'],
+      ['BUILD_GRAPH', 'OTP2_BUILD_GRAPH', 'EXPORT_NETEX_BLOCKS'],
       'BUILD_GRAPH'
     );
 
-    const bullets = this.bullet(formattedGroups, groups, locale, includeLevel2);
+    const bullets = this.bullet(formattedGroups, groups, locale, includeLevel2, hideIgnoredExportNetexBlocks);
 
     return (
       <div
@@ -281,7 +290,7 @@ class EventStepper extends React.Component {
         <div style={stepperstyle}>
           {bullets}
           <div
-            style={{ marginLeft: 'auto', marginRight: 20, marginTop: -50 }}
+            style={{ marginLeft: 'auto', marginRight: 20, marginTop: -25 }}
             onClick={() => this.handleToggleVisibility()}
           >
             {!expanded ? <FaChevronDown /> : <FaChevronUp />}

--- a/src/components/actionTranslations.js
+++ b/src/components/actionTranslations.js
@@ -28,6 +28,7 @@ export default {
       VALIDATION_LEVEL_2: 'Validering nivå 2',
       BUILD_GRAPH: 'Bygg av reisesøkforslag (otp1)',
       OTP2_BUILD_GRAPH: 'Bygg av reisesøkforslag (otp2)',
+      EXPORT_NETEX_BLOCKS: 'Eksport av NeTEx blocks',
       UNKNOWN: 'Ukjent steg'
     },
     title: {
@@ -39,6 +40,7 @@ export default {
       DATASPACE_TRANSFER: 'Overføring til sentralt databaseområde nivå 2',
       BUILD_GRAPH: 'Bygg av reisesøkforslag (otp1)',
       OTP2_BUILD_GRAPH: 'Bygg av reisesøkforslag (otp2)',
+      EXPORT_NETEX_BLOCKS: 'Eksport av NeTEx blocks',
       UNKNOWN: 'Dette steget er ukjent'
     },
     filename: {
@@ -91,6 +93,7 @@ export default {
       VALIDATION_LEVEL_2: 'Validation level 2',
       BUILD_GRAPH: 'Build graph (otp1)',
       OTP2_BUILD_GRAPH: 'Build graph (otp2)',
+      EXPORT_NETEX_BLOCKS: 'Export NeTEx blocks',
       UNKNOWN: 'Uknown step'
     },
     title: {
@@ -102,6 +105,7 @@ export default {
       DATASPACE_TRANSFER: 'Transfer to central dataspace - level 2',
       BUILD_GRAPH: 'Build graph (otp1)',
       OTP2_BUILD_GRAPH: 'Build graph (otp2)',
+      EXPORT_NETEX_BLOCKS: 'Export NeTEx blocks',
       UNKNOWN: 'This step is uknown'
     },
     filename: {

--- a/tests/mock/eventsDatasource.js
+++ b/tests/mock/eventsDatasource.js
@@ -19484,5 +19484,144 @@ export default [
     endState: 'TIMEOUT',
     fileName: null,
     providerId: 2
+  },
+  {
+    correlationId: "eb67f77f-c9de-4c88-92fd-b0bb2a0b745f",
+    durationMillis: 4800913,
+    endState: "OK",
+    errorCode: null,
+    events: [
+        {
+          "state": "PENDING",
+          "date": 1614810601131,
+          "action": "VALIDATION_LEVEL_1",
+          "chouetteJobId": null,
+          "referential": "tro"
+        },
+        {
+          "state": "STARTED",
+          "date": 1614810603521,
+          "action": "VALIDATION_LEVEL_1",
+          "chouetteJobId": 197227,
+          "referential": "tro"
+        },
+        {
+          "state": "OK",
+          "date": 1614810784987,
+          "action": "VALIDATION_LEVEL_1",
+          "chouetteJobId": 197227,
+          "referential": "tro"
+        },
+        {
+          "state": "PENDING",
+          "date": 1614810785006,
+          "action": "DATASPACE_TRANSFER",
+          "chouetteJobId": null,
+          "referential": "tro"
+        },
+        {
+          "state": "OK",
+          "date": 1614811326243,
+          "action": "DATASPACE_TRANSFER",
+          "chouetteJobId": 197357,
+          "referential": "tro"
+        },
+        {
+          "state": "PENDING",
+          "date": 1614811326275,
+          "action": "VALIDATION_LEVEL_2",
+          "chouetteJobId": null,
+          "referential": "tro"
+        },
+        {
+          "state": "OK",
+          "date": 1614811508794,
+          "action": "VALIDATION_LEVEL_2",
+          "chouetteJobId": 197410,
+          "referential": "rb_tro"
+        },
+        {
+          "state": "PENDING",
+          "date": 1614811508914,
+          "action": "EXPORT_NETEX",
+          "chouetteJobId": null,
+          "referential": "rb_tro"
+        },
+        {
+          "state": "OK",
+          "date": 1614811930331,
+          "action": "EXPORT_NETEX",
+          "chouetteJobId": 197424,
+          "referential": "rb_tro"
+        },
+        {
+          "state": "PENDING",
+          "date": 1614811930454,
+          "action": "EXPORT",
+          "chouetteJobId": null,
+          "referential": "rb_tro"
+        },
+        {
+          "state": "PENDING",
+          "date": 1614811930550,
+          "action": "EXPORT_NETEX_BLOCKS",
+          "chouetteJobId": null,
+          "referential": "rb_tro"
+        },
+        {
+          "state": "PENDING",
+          "date": 1614811932828,
+          "action": "BUILD_GRAPH",
+          "chouetteJobId": 197424,
+          "referential": "rb_tro"
+        },
+        {
+          "state": "OK",
+          "date": 1614812174761,
+          "action": "EXPORT",
+          "chouetteJobId": 197433,
+          "referential": "rb_tro"
+        },
+        {
+          "state": "OK",
+          "date": 1614812535454,
+          "action": "EXPORT_NETEX_BLOCKS",
+          "chouetteJobId": 197434,
+          "referential": "rb_tro"
+        },
+        {
+          "state": "STARTED",
+          "date": 1614813060489,
+          "action": "OTP2_BUILD_GRAPH",
+          "chouetteJobId": 197424,
+          "referential": "rb_tro"
+        },
+        {
+          "state": "STARTED",
+          "date": 1614813534731,
+          "action": "BUILD_GRAPH",
+          "chouetteJobId": 197424,
+          "referential": "rb_tro"
+        },
+        {
+          "state": "OK",
+          "date": 1614814612979,
+          "action": "OTP2_BUILD_GRAPH",
+          "chouetteJobId": 197424,
+          "referential": "rb_tro"
+        },
+        {
+          "state": "OK",
+          "date": 1614815402044,
+          "action": "BUILD_GRAPH",
+          "chouetteJobId": 197424,
+          "referential": "rb_tro"
+        }
+    ],
+    fileName: null,
+    firstEvent: 1614810601131,
+    lastEvent: 1614815402044,
+    providerId: 15,
+    username: "unknown"
   }
 ];


### PR DESCRIPTION
![Screenshot 2021-03-04 at 20 32 40](https://user-images.githubusercontent.com/231492/110019517-db84a800-7d28-11eb-8f10-0fa6e7a79e2f.png)

Includes a prop on the EventsDetail component `hideIgnoredExportNetexBlocks` which when you set it to true will only show the export netex blocks event icon if there are export netex blocks events.